### PR TITLE
Update for Glyphs 3, Python 3

### DIFF
--- a/CollectHangul.glyphsPlugin/Contents/Resources/plugin.py
+++ b/CollectHangul.glyphsPlugin/Contents/Resources/plugin.py
@@ -11,6 +11,7 @@
 #
 ###########################################################################################################
 
+from __future__ import division, print_function, unicode_literals
 import objc
 from GlyphsApp import *
 from GlyphsApp.plugins import *
@@ -20,6 +21,7 @@ LANGUAGES = {'Eng':0, 'Kor': 1}
 defaultID = u'com.LineGap.CollectHangul'
 
 class CollectHangul(GeneralPlugin):
+	@objc.python_method
 	def settings(self):
 		self.lang = LANGUAGES['Eng']
 		if Glyphs.defaults['%s.language' % defaultID] in [0, 1]:
@@ -28,10 +30,11 @@ class CollectHangul(GeneralPlugin):
 		self.menuName = ['_Collect Hangul', u'_한글 모으기'][self.lang]
 		self.numWindows = [0]
 
+	@objc.python_method
 	def start(self):
 		try: 
 			targetMenu = FILTER_MENU
-			newMenuItem = NSMenuItem(self.menuName, self.showWindow)
+			newMenuItem = NSMenuItem(self.menuName, self.showWindow_)
 			Glyphs.menu[targetMenu].insert(2, newMenuItem)
 		except:
 			mainMenu = Glyphs.mainMenu()
@@ -39,9 +42,9 @@ class CollectHangul(GeneralPlugin):
 			newMenuItem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(self.menuName, s, "")
 			newMenuItem.setTarget_(self)
 			mainMenu.itemWithTag_(11).submenu().insertItem_atIndex_(newMenuItem, 2)#addItem_(newMenuItem)
-			print traceback.format_exc()
+			print(traceback.format_exc())
 
-	def showWindow(self, sender):
+	def showWindow_(self, sender):
 		""" Do something like show a window"""
  		try:
  			if 0 == len(Glyphs.fonts):
@@ -66,8 +69,9 @@ class CollectHangul(GeneralPlugin):
  			CH.Run(self.numWindows, self.lang)
 
  		except:
- 			print traceback.format_exc()
+ 			print(traceback.format_exc())
 
+	@objc.python_method
 	def __file__(self):
 		"""Please leave this method unchanged"""
 		return __file__


### PR DESCRIPTION
We received this error report from a user:

```
CollectHangul.glyphsPlugin 플러그인으로 인해 글립스앱이 충돌하였습니다. 플러그인매니저에서 업데이트 또는 다시 다운로드 받으시기 바랍니다. 

설명:  File "plugin.py", line 42

   print traceback.format_exc()

         ^

SyntaxError: invalid syntax

App:3.0.2-3058 Plugin:1.7-5
```

The proposed changes should fix it.